### PR TITLE
[TASK] Introduce constraint with t3quixplorer

### DIFF
--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -39,6 +39,7 @@ $EM_CONF[$_EXTKEY] = array(
 			'extbase' => '',
 		),
 		'conflicts' => array(
+			't3quixplorer' => '',
 		),
 		'suggests' => array(
 		),


### PR DESCRIPTION
Sad, but true. TYPO3 Administrators still allow the extension 
t3quixplorer to be installed as it still works and they dont
know it any better.

t3quixplorer doesn't use proper language files and thus should be marked as conflicting.

Fixes #1
