### PR TITLE
[TASK] Test for PHP 5.6 for LTS (master) with travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: php
 php:
   - 5.3
   - 5.4
+  - 5.5
 
 env:
   - DB=mysql TYPO3=master INTEGRATION=master
@@ -10,7 +11,7 @@ env:
 
 matrix:
    include:
-     - php: 5.5
+     - php: 5.6
        env: DB=mysql TYPO3=master INTEGRATION=master
 
 before_script:


### PR DESCRIPTION
Moved 5.5 to all builds because TYPO3 supports officially PHP 5.5 in TYPO3 6.0
